### PR TITLE
fix for #67 Batarang fails to inject provider with array syntax

### DIFF
--- a/js/inject/debug.js
+++ b/js/inject/debug.js
@@ -629,6 +629,17 @@ var inject = function () {
                 return tempGet.apply(this, arguments);
               };
             });
+          } else if (definition instanceof Array) {
+            // it is a constructoctor with array syntax
+            var tempConstructor = definition[definition.length - 1];
+
+            definition[definition.length - 1] = function () {
+              debug.deps.push({
+                name: name,
+                imports: annotate(tempConstructor)
+              });
+              return tempConstructor.apply(this, arguments);
+            };
           } else if (definition.$get instanceof Array) {
             // it should have a $get
             var tempGet = definition.$get[definition.$get.length - 1];


### PR DESCRIPTION
Fixes issue #67, Batarang breaks Angular application if the application uses a provider with a constructor with an array signature.

I have tested this code against 3 large Angular applications without any issue. However please have a look at the code before merging.

Let me know if anything needs to be changed.
