### PR TITLE
Show brief information for each scope on 'Model' and 'Performance' tabs

### DIFF
--- a/css/panel.css
+++ b/css/panel.css
@@ -43,6 +43,12 @@ bat-scope-tree .selected {
   color: #333;
 }
 
+bat-scope-tree dfn {
+  font-style: normal;
+  color: #52a3cc;
+  font-size: 0.9em;
+}
+
 /*
  * Slider widget style based on jquery-ui-bootstrap
  * http://addyosmani.github.com/jquery-ui-bootstrap

--- a/js/directives/scopeTree.js
+++ b/js/directives/scopeTree.js
@@ -1,4 +1,4 @@
-angular.module('panelApp').directive('batScopeTree', function ($compile) {
+angular.module('panelApp').directive('batScopeTree', function ($compile, renderScope) {
 
   // make toggle settings persist across $compile
   var modelState = {};
@@ -9,7 +9,7 @@ angular.module('panelApp').directive('batScopeTree', function ($compile) {
   var template =
     '<div class="scope-branch">' +
       '<a href ng-click="inspect()">&lt;</a> ' +
-      '<a href ng-click="select()" ng-class="{selected: selectedScope == val.id}">Scope ({{val.id}})</a>' +
+      '<a href ng-click="select()" ng-class="{selected: selectedScope == val.id}" ng-bind-html-unsafe="name"></a>' +
       '<div ng-repeat="child in val.children">' +
         '<bat-scope-tree ' +
           'val="child" ' +
@@ -35,7 +35,9 @@ angular.module('panelApp').directive('batScopeTree', function ($compile) {
       element.append(template);
 
       var childScope = scope.$new();
-
+      scope.$watch('val', function(newVal) {
+        childScope.name = renderScope(scope.val);
+      });
       childScope.select = scope.select;
       //childScope.selectedScope = scope.selectedScope;
       childScope.inspect = scope.inspect;

--- a/js/directives/watcherTree.js
+++ b/js/directives/watcherTree.js
@@ -1,5 +1,5 @@
 // watchers tree
-angular.module('panelApp').directive('batWatcherTree', function($compile) {
+angular.module('panelApp').directive('batWatcherTree', function($compile, renderScope) {
 
   // make toggle settings persist across $compile
   var scopeState = {};
@@ -16,7 +16,7 @@ angular.module('panelApp').directive('batWatcherTree', function($compile) {
       // see: https://github.com/angular/angular.js/issues/898
       element.append(
         '<div class="scope-branch">' +
-          '<a href ng-click="inspect()">Scope ({{val.id}})</a> | ' +
+          '<a href ng-click="inspect()" ng-bind-html-unsafe="name"></a> | ' +
           '<a href ng-click="scopeState[val.id] = !scopeState[val.id]">toggle</a>' +
           '<div ng-hide="scopeState[val.id]">' +
             '<ul>' +
@@ -35,6 +35,9 @@ angular.module('panelApp').directive('batWatcherTree', function($compile) {
         '</div>');
 
       var childScope = scope.$new();
+      scope.$watch('val', function(newVal) {
+        childScope.name = renderScope(newVal);
+      });
       childScope.scopeState = scopeState;
 
       $compile(element.contents())(childScope);

--- a/js/inject/debug.js
+++ b/js/inject/debug.js
@@ -1058,9 +1058,6 @@ var inject = function () {
           if (angular.isArray(df)) {
             df[df.length - 1] = patchDirectiveFunction(name, df[df.length - 1])
           }
-          else if (angular.isObject(df)) {
-            df.$get = patchDirectiveFunction(name, df.$get)
-          }
           else if (angular.isFunction(df)) {
             return patchDirectiveFunction(name, df);
           }

--- a/js/inject/debug.js
+++ b/js/inject/debug.js
@@ -1021,7 +1021,6 @@ var inject = function () {
         var tempDirective = $compileProvider.directive;
 
         $compileProvider.directive = function (name, directiveFactory) {
-          console.log(name, directiveFactory);
           if (angular.isString(name)) {
             debug.directiveNames.push(name);
           }

--- a/js/inject/debug.js
+++ b/js/inject/debug.js
@@ -609,9 +609,9 @@ var inject = function () {
               } else if (val === null) {
                 toAppend = '<i>null</i>';
               } else if (val instanceof Array) {
-                toAppend = '[ ... ]';
+                toAppend = objectId(val);
               } else if (val instanceof Object) {
-                toAppend = '{ ... }';
+                toAppend = objectId(val);
               } else {
                 toAppend = val.toString();
               }

--- a/js/inject/debug.js
+++ b/js/inject/debug.js
@@ -250,6 +250,127 @@ var inject = function () {
         debug.scopeDirty[scope.$id] = false;
       };
 
+
+      //converts camelCase to snake-case
+      var snakeCase = function (inCamelCase, delimiter) {
+        return inCamelCase.split(/(?=[A-Z])/).map(function (p) {
+          return p.toLowerCase()
+        }).join(delimiter || "-");
+      };
+
+      //see objectId.js
+      var objectId = ngTool().objectId;
+
+      // gets name of user-defined directive which introduced new scope for the DOM element
+      // for now works with Attribute and Element directives only
+      // does not work if 'replace' flag for directive is true
+      var getScopeSourceDirective = function (el) {
+        var directive = debug.directives['E-' + el.tagName.toLowerCase()];
+        if (directive && directive.newScope) return directive;
+        for (var i = 0; i < el.attributes.length; i++) {
+          directive = debug.directives['A-' + el.attributes[i].name.toLowerCase()];
+          if (directive && directive.newScope) return directive;
+        }
+        return undefined;
+      };
+
+
+      // Tries to give human-readable name to each scope using the following:
+      // - controller name
+      // - user-defined directive name
+      // - ngRepeat iterated item object
+      // - ngInclude source
+      // - __name attribute of the scope (may be used for debug)
+      var collectScopeNames = function () {
+
+        function getScope(jq) {
+          //for angular 1.2 we need to check isolateScope as well
+          return (jq.hasClass('ng-isolate-scope') && jq.isolateScope) ? jq.isolateScope() : jq.scope();
+        }
+
+        function controllerName (obj, el) {
+          if (!el.hasAttribute('ng-controller')) {
+            return;
+          }
+          obj.controller = el.getAttribute("ng-controller");
+        }
+
+        function directiveName (obj, el) {
+          var directive = getScopeSourceDirective(el);
+          if (!directive) {
+            return;
+          }
+          obj.directive = directive.name;
+        }
+
+        function ngRepeat (obj, el, scope) {
+          if (!el.hasAttribute('ng-repeat')) {
+            return;
+          }
+          var expr = el.getAttribute('ng-repeat');
+          //TODO: for object it is probably better to read value, not key
+          var itemExpr = expr.split('in')[0].split(",")[0].replace(/^\(/, '').trim();
+          var item = scope.$eval(itemExpr);
+          if (item) {
+            obj.ngRepeat = {
+                index: scope.$index,
+                itemExpr: itemExpr,
+                itemId: objectId(item)
+            }
+          }
+        }
+
+        function ngInclude (obj, el, scope) {
+          if (el.hasAttribute('ng-include')) {
+            obj.ngInclude = scope.$eval(el.getAttribute('ng-include'));
+          }
+          if (el.tagName == "NG-INCLUDE") {
+            obj.ngInclude = scope.$eval(el.getAttribute('src'));
+          }
+        }
+
+        //for directives like ng-include the scope for corresponding dom element is actually the parent scope,
+        // so we need to get scope of first child (if it does not have its own isolated scope)
+        function correctScope (el, scope) {
+          if (el.hasAttribute('ng-include') || el.tagName == 'NG-INCLUDE') {
+            var $el = angular.element(el), firstChild = $el.children()[0];
+            if (firstChild) {
+              var childScope = getScope(angular.element(firstChild));
+              if (childScope.$parent != scope) {
+                //there is one more scope inside
+                childScope = childScope.$parent;
+              }
+              return childScope;
+            }
+          }
+          return scope;
+        }
+
+        function parseNode (el, scope) {
+          var res = {};
+          controllerName(res, el);
+          directiveName(res, el);
+          ngRepeat(res, el, scope);
+          ngInclude(res, el, scope);
+          return Object.keys(res).length == 0 ? undefined : res;
+        }
+
+        function saveScopeName (el) {
+          var $el = angular.element(el);
+          var scope = getScope($el);
+          var realScope = correctScope(el, scope);
+          if (angular.isDefined(debug.scopeNames[realScope.$id])) {
+            return;
+          }
+          debug.scopeNames[realScope.$id] = parseNode(el, scope);
+        }
+
+        debug.scopeNames = {};
+        ["[ng-controller]", ".ng-scope", ".ng-isolate-scope", "[ng-repeat]", "[ng-include]", "ng-include"].forEach(function (selector) {
+          angular.forEach(document.querySelectorAll(selector), saveScopeName);
+        });
+      };
+
       var popover = null;
 
       // Public API
@@ -281,9 +402,11 @@ var inject = function () {
           if (debug.scopeTreeDirty[id] === false) {
             return;
           }
+          collectScopeNames();
           var traverse = function (sc) {
             var tree = {
               id: sc.$id,
+              name: sc.__name || debug.scopeNames[sc.$id],
               children: []
             };
 
@@ -323,9 +446,12 @@ var inject = function () {
         },
 
         getWatchTree: function (id) {
+          //TODO: here we may cache the scope names and do not collect them on each call
+          collectScopeNames();
           var traverse = function (sc) {
             var tree = {
               id: sc.$id,
+              name: sc.__name || debug.scopeNames[sc.$id],
               watchers: debug.watchers[sc.$id],
               children: []
             };
@@ -595,6 +721,8 @@ var inject = function () {
 
         // map of scope.$ids --> $scope objects
         scopes: {},
+        // map of scope.$ids --> $scope human readable names (as string or as object with several 'type': 'name' strings)
+        scopeNames: {},
         // map of scope.$ids --> model objects
         models: {},
         // map of $ids --> bools
@@ -604,7 +732,13 @@ var inject = function () {
         rootScopes: {},
         scopeTreeDirty: {},
 
-        deps: []
+        deps: [],
+
+        // map of directive names in form '<restrict>-snake-case' --> {name: <camelCase>, newScope: <true/false>}
+        // for directives with multiple restricts there will be several records
+        directives: {},
+        //list of directive names registered by user
+        directiveNames: []
       };
 
 
@@ -881,11 +1015,41 @@ var inject = function () {
           return $delegate;
         });
       });
+
+      // Here we collect user-defined directives
+      ng.config(function patchCompileProvider ($compileProvider) {
+        var tempDirective = $compileProvider.directive;
+
+        $compileProvider.directive = function (name, directiveFactory) {
+          console.log(name, directiveFactory);
+          if (angular.isString(name)) {
+            debug.directiveNames.push(name);
+          }
+          else {
+            angular.forEach(name, function (directiveFactory, name) {
+              debug.directiveNames.push(name);
+            });
+          }
+          return tempDirective.apply(this, arguments);
+        };
+      });
+
+      ng.run(function readDirectiveOptions ($injector) {
+        angular.forEach(debug.directiveNames, function(name) {
+          var directives = $injector.get(name + 'Directive');
+          angular.forEach(directives, function(def) {
+            angular.forEach((def.restrict || 'A').split(''), function(restrictType) {
+              debug.directives[restrictType + '-' + snakeCase(name)] = {name: name, newScope: !!def.scope};
+              //TODO: patch directive to add something to element which will refer to the directive name if 'replace' flag is true
+            });
+          });
+        });
+      });
     };
 
     // Return a script element with the above code embedded in it
     var script = window.document.createElement('script');
-    script.innerHTML = '(' + fn.toString() + '(window))';
+    script.innerHTML = ngTool.toString() + ';\n' + '(' + fn.toString() + '(window))';
 
     return script;
   }()));

--- a/js/inject/objectId.js
+++ b/js/inject/objectId.js
@@ -1,0 +1,54 @@
+//Several tool methods extracted from debug.js in order to write unit tests on them
+function ngTool() {
+
+  // Gets attribute from the object which looks like object identifier - id, name, email, etc.
+  function getIdAttribute (obj) {
+    if (window.angular.isString(obj)) {
+      return undefined;
+    }
+    var possibleIdAttrs = ['__id', 'Email', 'Mail', 'FullName', 'full_name', 'Name', 'Title', 'Subject', 'Id', '_id', '$id'];
+    for (var i = 0; i < possibleIdAttrs.length; i++) {
+      var attrName = possibleIdAttrs[i];
+      var firstExistent = [attrName, attrName.toLowerCase()].filter(function(variation) {return !!obj[variation];})[0];
+      if (firstExistent) return firstExistent;
+    }
+    return undefined;
+  }
+
+  function withoutAngularInternal (keys) {
+    var angularInternal = ["$$hashKey"];
+    return keys.filter(function(key) {
+      return angularInternal.indexOf(key) == -1;
+    });
+  }
+
+  var __ngTool = {};
+
+  // Renders provided object (or array) to the string which briefily describes the object:
+  // - for array renders only first element
+  // - for object renders only attribute which looks like object identifier - id, name, email, etc.
+  // - for primitive values render themselves
+  // It could be used in order to show some brief information about object without printing whole object - in lists, trees, etc.,
+  // so it is easier to read.
+  var objectId = __ngTool.objectId = function (obj) {
+    var rest = '';
+    if (window.angular.isArray(obj)) {
+      var firstItem = obj.length > 0 ? objectId(obj[0]) : '';
+      if (obj.length > 1) rest = ", ...";
+      return "[ " + firstItem + rest + " ]";
+    }
+    else if (window.angular.isObject(obj)) {
+      var keys = withoutAngularInternal(Object.keys(obj));
+      var idAttr = getIdAttribute(obj) || keys[0];
+      var idExpr = idAttr ? (idAttr + ": " + objectId(obj[idAttr])) : "";
+      if (keys.length > 1) rest = ", ...";
+      return "{ " + idExpr + rest + " }";
+    }
+    else {
+      return JSON.stringify(obj);
+    }
+  };
+
+  return __ngTool;
+
+}

--- a/js/inject/objectId.js
+++ b/js/inject/objectId.js
@@ -22,6 +22,10 @@ function ngTool() {
     });
   }
 
+  function toString(obj) {
+    return JSON.stringify(obj).replace(/</g, '&lt;').replace(/>/g, '&gt;')
+  }
+
   var __ngTool = {};
 
   // Renders provided object (or array) to the string which briefily describes the object:
@@ -45,7 +49,7 @@ function ngTool() {
       return "{ " + idExpr + rest + " }";
     }
     else {
-      return JSON.stringify(obj);
+      return toString(obj);
     }
   };
 

--- a/js/services/appContext.js
+++ b/js/services/appContext.js
@@ -16,11 +16,13 @@ angular.module('panelApp').factory('appContext', function (chromeExtension) {
       args.scopeId = scopeId;
       args.fn = fn.toString();
 
+      // Angular 1.2 adds ng-isolate-scope without ng-scope
       chromeExtension.eval("function (window, args) {" +
-        "var elts = window.document.getElementsByClassName('ng-scope'), i;" +
+        "var doc = window.document, slice = Array.prototype.slice, scopes = doc.getElementsByClassName('ng-scope'), isoScopes = doc.getElementsByClassName('ng-isolate-scope'), " +
+        "elts = slice.call(scopes).concat(slice.call(isoScopes)), i;" +
         "for (i = 0; i < elts.length; i++) {" +
           "(function (elt) {" +
-            "var $scope = window.angular.element(elt).scope();" +
+            "var el = window.angular.element(elt), $scope = el.hasClass('ng-scope') ? el.scope() : el.isolateScope();" +
             "if ($scope.$id === args.scopeId) {" +
               "(" + args.fn + "($scope, elt, args));" +
             "}" +

--- a/js/services/scopeRender.js
+++ b/js/services/scopeRender.js
@@ -1,11 +1,17 @@
 //Renders scope name according to how it was created - for controller, for directive, etc.
 //See debug.js#collectScopes
 angular.module('panelApp').factory('renderScope', function() {
+  function notLongerThan(str, len) {
+    if (str.length > len) {
+      return str.slice(0, len) + '...';
+    }
+    return str;
+  }
   var render = {
     scopeIdSuffix: function(scope) {return " (" + scope.id + ")"},
     controller: function(scope, data) { return "<dfn>controller</dfn> '" + data + "'"},
     directive: function(scope, data) { return "<dfn>directive</dfn> '" + data + "'"},
-    ngRepeat: function(scope, data) { return "<dfn>" + data.index + ". " + data.itemExpr + "</dfn> " + data.itemId },
+    ngRepeat: function(scope, data) { return "<dfn>" + data.index + ". " + data.itemExpr + "</dfn> " + notLongerThan(data.itemId, 100) },
     ngInclude: function(scope, data) { return data }
   };
 

--- a/js/services/scopeRender.js
+++ b/js/services/scopeRender.js
@@ -1,0 +1,27 @@
+//Renders scope name according to how it was created - for controller, for directive, etc.
+//See debug.js#collectScopes
+angular.module('panelApp').factory('renderScope', function() {
+  var render = {
+    scopeIdSuffix: function(scope) {return " (" + scope.id + ")"},
+    controller: function(scope, data) { return "<dfn>controller</dfn> '" + data + "'"},
+    directive: function(scope, data) { return "<dfn>directive</dfn> '" + data + "'"},
+    ngRepeat: function(scope, data) { return "<dfn>" + data.index + ". " + data.itemExpr + "</dfn> " + data.itemId },
+    ngInclude: function(scope, data) { return data }
+  };
+
+  function renderName(scope) {
+    if (angular.isString(scope.name)) {
+      return "Scope (" + scope.name + ")";
+    }
+    else if (angular.isObject(scope.name)) {
+      var names = [];
+      angular.forEach(scope.name, function (data, type) {
+        names.push(render[type](scope, data));
+      });
+      return names.join(", ") + render.scopeIdSuffix(scope);
+    }
+    return "Scope (" + scope.id + ")";
+  }
+
+  return renderName;
+});

--- a/karma.conf
+++ b/karma.conf
@@ -10,6 +10,7 @@ files = [
   'js/directives/*.js',
   'js/filters/*.js',
   'js/services/*.js',
+  'js/inject/objectId.js',
 
   'test/mock/*.js',
   'test/*.js'

--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,7 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
-      "js": ["js/inject/debug.js"],
+      "js": ["js/inject/objectId.js", "js/inject/debug.js"],
       "run_at": "document_start"
     }
   ],

--- a/panel.html
+++ b/panel.html
@@ -36,6 +36,7 @@
   <script src="js/services/appWatch.js"></script>
   <script src="js/services/chromeExtension.js"></script>
   <script src="js/services/filesystem.js"></script>
+  <script src="js/services/scopeRender.js"></script>
 
   <script src="js/controllers/DepsCtrl.js"></script>
   <script src="js/controllers/ModelCtrl.js"></script>

--- a/test/objectIdSpec.js
+++ b/test/objectIdSpec.js
@@ -1,0 +1,61 @@
+
+describe('objectId function', function() {
+  var objectId = ngTool().objectId;
+
+  it('should render string as string itself', function() {
+    expect(objectId('test')).toEqual('"test"');
+  });
+
+  it('should render number as string', function() {
+    expect(objectId(4)).toEqual('4');
+  });
+
+  it('should render empty object as {}', function() {
+    expect(objectId({})).toEqual('{  }')
+  });
+
+  it('should render object with single attribute', function() {
+    expect(objectId({a: 3})).toEqual('{ a: 3 }');
+  });
+
+  it('should render first attribute for object with several', function () {
+    expect(objectId({a: 3, b: 4})).toEqual('{ a: 3, ... }');
+  });
+
+  it('should render id-like attribute even it is not first one', function() {
+    expect(objectId({site: 'google.com', version: '0.3.2', email: 'frodo@shire.me'})).toEqual('{ email: "frodo@shire.me", ... }');
+  });
+
+  it('should render empty array as []', function() {
+    expect(objectId([])).toEqual('[  ]');
+  });
+
+  it('should render array with single item', function() {
+    expect(objectId([4])).toEqual('[ 4 ]');
+  });
+
+  it('should render only first item for array with several', function() {
+    expect(objectId([3,4,5])).toEqual('[ 3, ... ]');
+  });
+
+  it('should render id-like attribute of first object in array', function() {
+    expect(objectId([{comments: 4, subject: "Hello!"}, {comment: 4, subject: "Re: Hello!"}])).toEqual('[ { subject: "Hello!", ... }, ... ]');
+  });
+
+  it('should correctly render nested structures/arrays', function() {
+    expect(objectId({
+      name: [
+        [
+          [
+            {mail: {id: [3]}, version: 2}
+          ]
+        ]
+      ]
+    })).toEqual('{ name: [ [ [ { mail: { id: [ 3 ] }, ... } ] ] ] }');
+  });
+
+  it('should ignore angular.js internal keys', function() {
+    expect(objectId({item: 3, $$hashKey: 30})).toEqual("{ item: 3 }");
+  });
+
+});

--- a/test/objectIdSpec.js
+++ b/test/objectIdSpec.js
@@ -58,4 +58,8 @@ describe('objectId function', function() {
     expect(objectId({item: 3, $$hashKey: 30})).toEqual("{ item: 3 }");
   });
 
+  it('should convert HTML characters to entities', function() {
+    expect(objectId({name: "<b>hello</b>"})).toEqual('{ name: "&lt;b&gt;hello&lt;/b&gt;" }')
+  });
+
 });


### PR DESCRIPTION
Hi,

I think it would be useful to see something more descriptive than 'Scope (<id>)' in the Models and Performance tabs. This change adds some brief information about scope - at least controller name, directive name, ng-include source and ng-repeat item description.

Also you may define scope attribute __name in your controller/directive and it will be shown instead of id.

Please refer to the screenshots:
### Before

![batarang-todo-before](https://f.cloud.github.com/assets/2125405/1845239/428362d0-757a-11e3-88ed-7838f0cc1a8f.png)
### After

![batarang-todo-after](https://f.cloud.github.com/assets/2125405/1845240/45eeca22-757a-11e3-921f-c1a3fcaf5155.png)
### Before

![batarang-before](https://f.cloud.github.com/assets/2125405/1845241/48fbbfd6-757a-11e3-8fe6-3f5c541874d2.png)
### After

![batarang-after](https://f.cloud.github.com/assets/2125405/1845242/4bf66222-757a-11e3-9737-736e825b8000.png)
### Known issues
- nothing specific is shown for ngView/ngSwitch
- directive name is shown only if 'replace' flag is not set to 'true'
- scope names are collected on each 'poll' event for Performance tab even nothing is changed. There shall be caching for it.

Looking for your feedback, thanks.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/angularjs-batarang/99)

<!-- Reviewable:end -->
