### PR TITLE
Performance tab improvements

### DIFF
--- a/css/panel.css
+++ b/css/panel.css
@@ -10,6 +10,11 @@
   margin-left: 30px;
   background-color: rgba(0,0,0,0.06);
 }
+.ellipsis {
+    margin-left: 30px;
+    margin-bottom: 10px;
+    font-family: monospace;
+}
 body {
   margin: 10px;
 }

--- a/css/panel.css
+++ b/css/panel.css
@@ -104,3 +104,7 @@ bat-scope-tree .selected {
   background-image: -webkit-linear-gradient(top, #049cdb, #0064cd);
   /*background-image: linear-gradient(top, #049cdb, #0064cd);*/
 }
+
+[ng-cloak] {
+    display: none;
+}

--- a/js/directives/slider.js
+++ b/js/directives/slider.js
@@ -19,6 +19,9 @@ angular.module('panelApp').directive('batSlider', function($compile) {
 
       $compile(element.contents())(scope.$new());
 
+      scope.$watch('minimum', updateSlider);
+      scope.$watch('maximum', updateSlider);
+
       dom.slider({
         range: true,
         values: [0, 100],
@@ -37,6 +40,10 @@ angular.module('panelApp').directive('batSlider', function($compile) {
           scope.$apply();
         }
       });
+
+      function updateSlider() {
+        dom.slider('values', [scope.minimum, scope.maximum]);
+      }
 
     }
   };

--- a/js/directives/watcherTree.js
+++ b/js/directives/watcherTree.js
@@ -1,8 +1,12 @@
 // watchers tree
-angular.module('panelApp').directive('batWatcherTree', function($compile) {
+angular.module('panelApp').directive('batWatcherTree', function($compile, composingQueue) {
 
   // make toggle settings persist across $compile
   var scopeState = {};
+
+  //show only several first and last scopes - for big lists it is useless to see all items, at least on performance tab
+  //TODO: add ability to see all (if someone needs it)
+  var showFirstChildren = 25, showLastChildren = 25, needToBreak = showFirstChildren + showLastChildren + 2;
 
   return {
     restrict: 'E',
@@ -12,10 +16,11 @@ angular.module('panelApp').directive('batWatcherTree', function($compile) {
       inspect: '=inspect'
     },
     link: function (scope, element, attrs) {
+      var level = parseInt(attrs.level || "1");
       // this is more complicated then it should be
       // see: https://github.com/angular/angular.js/issues/898
       element.append(
-        '<div class="scope-branch">' +
+        '<div class="scope-branch" ng-cloak>' +
           '<a href ng-click="inspect()">Scope ({{val.id}})</a> | ' +
           '<a href ng-click="scopeState[val.id] = !scopeState[val.id]">toggle</a>' +
           '<div ng-hide="scopeState[val.id]">' +
@@ -28,16 +33,35 @@ angular.module('panelApp').directive('batWatcherTree', function($compile) {
                 '</pre>' +
               '</li>' +
             '</ul>' +
-            '<div ng-repeat="child in val.children">' +
-              '<bat-watcher-tree val="child" inspect="inspect"></bat-watcher-tree>' +
-            '</div>' +
+            '<ng-switch on="val.children.length >= ' + needToBreak + '">' +
+
+              '<div ng-switch-when="true">' +
+                '<div ng-repeat="child in val.children | limitTo:' + showFirstChildren + '">' +
+                  '<bat-watcher-tree val="child" inspect="inspect" level="' + (level + 1) + '"></bat-watcher-tree>' +
+                '</div>' +
+                '<div class="ellipsis"> {{val.children.length - ' + (needToBreak-1) + '}} scope(s) skipped  </div>' +
+                '<div ng-repeat="child in val.children | limitTo:-' + showLastChildren + '">' +
+                  '<bat-watcher-tree val="child" inspect="inspect" level="' + (level + 1) + '"></bat-watcher-tree>' +
+                '</div>' +
+              '</div>' +
+              '<div ng-switch-default>' +
+                '<div ng-repeat="child in val.children">' +
+                  '<bat-watcher-tree val="child" inspect="inspect" level="' + (level + 1) + '"></bat-watcher-tree>' +
+                '</div>' +
+              '</div>' +
+            '</ng-switch>' +
+
           '</div>' +
         '</div>');
 
       var childScope = scope.$new();
       childScope.scopeState = scopeState;
 
-      $compile(element.contents())(childScope);
+      //compose tree in background, otherwise UI freezes for long
+      composingQueue.addToQueue(function() {
+        $compile(element.contents())(childScope);
+      });
+
     }
   };
 });

--- a/js/filters/sortByTime.js
+++ b/js/filters/sortByTime.js
@@ -12,9 +12,10 @@ angular.module('panelApp').filter('sortByTime', function () {
       return copy;
     }
 
-    var start = Math.floor(input.length * min/100);
-    var end = Math.ceil(input.length * max/100) - start;
-
-    return copy.splice(start, end);
+    // Previous implementation was very strange. I think it is more obvious to work this way:
+    //   to show only those watchers with percentages >= min and <= max.
+    return copy.filter(function(data) {
+      return data.percent >= min && data.percent <= max;
+    });
   };
 });

--- a/js/inject/debug.js
+++ b/js/inject/debug.js
@@ -902,6 +902,8 @@ var inject = function () {
         return {
           priority: 1001,
           compile: function() {
+            //Note: it is important to use pre-link function here - it is guaranteed that it will be executed before original ngRepeat
+            // starting from angular 1.1 post-link functions are called in reverse priorities order
             return {
               pre: function (scope, element, attr) {
                 var oldWatch = scope.$watch;

--- a/js/inject/debug.js
+++ b/js/inject/debug.js
@@ -901,14 +901,18 @@ var inject = function () {
       ng.directive('ngRepeat', function() {
         return {
           priority: 1001,
-          link: function (scope, element, attr) {
-            var oldWatch = scope.$watch;
-            scope.$watch = function(expr, listener) {
-              expr.__name = attr.ngRepeat;
-              var remove = oldWatch.apply(scope, arguments);
-              scope.$watch = oldWatch;
-              return remove;
-            };
+          compile: function() {
+            return {
+              pre: function (scope, element, attr) {
+                var oldWatch = scope.$watch;
+                scope.$watch = function(expr, listener) {
+                  expr.__name = 'ngRepeat: ' + attr.ngRepeat;
+                  var remove = oldWatch.apply(scope, arguments);
+                  scope.$watch = oldWatch;
+                  return remove;
+                };
+              }
+            }
           }
         };
       });

--- a/js/inject/debug.js
+++ b/js/inject/debug.js
@@ -330,7 +330,6 @@ var inject = function () {
             var tree = {
               id: sc.$id,
               watchers: debug.watchers[sc.$id],
-              watchersMap: {},
               children: []
             };
 

--- a/js/services/composingQueue.js
+++ b/js/services/composingQueue.js
@@ -1,0 +1,33 @@
+// Executes actions in background, by small portions (now 50 actions each 50 ms)
+// Could be used to build big views without freezing UI
+angular.module('panelApp').factory('composingQueue', function($timeout) {
+  var treeComposingQueue = [], queueTo = null;
+  function processQueue() {
+    if (treeComposingQueue.length == 0) {
+      queueTo = null;
+    }
+    else {
+      var toProcess = treeComposingQueue.splice(0, 50);
+      toProcess.forEach(function(action) {action()});
+      queueTo = $timeout(processQueue, 50);
+      api.queueLength = treeComposingQueue.length;
+    }
+  }
+  function addToQueue(action) {
+    treeComposingQueue.push(action);
+    api.queueLength++;
+    if (queueTo == null) {
+      processQueue();
+    }
+  }
+
+  var api = {
+    //adds action to the queue and executes it after all other actions. Could be executed right now or after approximately
+    // queueLength ms
+    addToQueue: addToQueue,
+
+    //current length of queue
+    queueLength: 0
+  };
+  return api;
+});

--- a/panel.html
+++ b/panel.html
@@ -36,6 +36,7 @@
   <script src="js/services/appWatch.js"></script>
   <script src="js/services/chromeExtension.js"></script>
   <script src="js/services/filesystem.js"></script>
+  <script src="js/services/composingQueue.js"></script>
 
   <script src="js/controllers/DepsCtrl.js"></script>
   <script src="js/controllers/ModelCtrl.js"></script>

--- a/panes/perf.html
+++ b/panes/perf.html
@@ -24,7 +24,7 @@
     <div class="span6">
       <h3>Watch Expressions</h3>
 
-      <div class="well well-top" style="height: 400px; overflow-y: auto;">
+      <div class="well well-top" style="height: 400px; overflow-y: scroll;">
         <div ng-repeat="watch in histogram|sortByTime:min:max">
           <span style="font-family: monospace;">{{watch.name | first}} </span>
           <span> | {{watch.percent}}% | {{watch.time | precision}}ms</span>
@@ -39,7 +39,7 @@
 
       <div class="well well-bottom">
         <form class="form-inline">
-          <label>Show expressions that takes from {{min}}% to {{max}}%</label>
+          <label>Show expressions that take from {{min}}% to {{max}}%</label>
           <bat-slider minimum="min" maximum="max"></bat-slider>
         </form>
         <button class="btn btn-success" ng-click="exportData()"><i class="icon-download-alt icon-white"></i> Save Data as JSON</button>

--- a/panes/perf.html
+++ b/panes/perf.html
@@ -9,6 +9,7 @@
 
   <div class="row-fluid">
     <div class="span6">
+      <span class="label label-info pull-right " ng-show="queueLength > 0"><i class="icon icon-repeat icon-white"></i>Building...</span>
       <h3>Watch Tree</h3>
       <div class="well well-top" style="height: 400px; overflow-y: auto;">
         <bat-watcher-tree val="tree" inspect="inspect"></bat-watcher-tree>
@@ -27,6 +28,8 @@
         <div ng-repeat="watch in histogram|sortByTime:min:max">
           <span style="font-family: monospace;">{{watch.name | first}} </span>
           <span> | {{watch.percent}}% | {{watch.time | precision}}ms</span>
+          <a class="pull-right" href ng-click="setMin(watch.percent)" ng-show="min < watch.percent && !$last">Hide below</a>
+          <a class="pull-right" href ng-click="setMin(0)" ng-show="min >= watch.percent && $last">Show all</a>
           <div class="progress">
             <div ng-style="{width: (watch.percent) + '%'}" class= "bar">
             </div>
@@ -36,7 +39,7 @@
 
       <div class="well well-bottom">
         <form class="form-inline">
-          <label>Filter expressions</label>
+          <label>Show expressions that takes from {{min}}% to {{max}}%</label>
           <bat-slider minimum="min" maximum="max"></bat-slider>
         </form>
         <button class="btn btn-success" ng-click="exportData()"><i class="icon-download-alt icon-white"></i> Save Data as JSON</button>


### PR DESCRIPTION
Hello,

There is a set of improvements for Performance tab (sorry for big set in one pull request, I may break into several if you'd like to):

### Behavior changes
+ in both watch tree and watch expressions the watches created by ngRepeat now marked with their expressions - so instead of multiple '$watchCollectionWatch' lines you'll see 'ngRepeat: <your-ng-repeat-expression>', like on the screenshot at the end
+ in watchers tree if some scope has more than 50 child scopes then only first 25 and last 25 are shown. I think that in most cases when you have >= 50 child scopes there is ngRepeat, and usually in ngRepeat all elements have almost same set of watch expressions so it is not needed to see all of them.
+ slider under watchers histogram worked some unoubvious way. Not sure was it planned so or not, but I'd like to suggest another behavior - slider defines which percentages shall be shown on histogram. If 0-50 then only expressions which take <= 50% will be shown, if 50-10 - then only those which take >= 50%.

### Improvements/fixes
+ watchers tree now is building "in background" without freezing UI
+ watchers tree is rebuilding only if some watch was added/removed
+ watchers tree on UI is rebuilt partially on update
+ Fix: "Log to console" checkbox now works

### Screenshots
![watches](https://f.cloud.github.com/assets/2125405/1846286/e2b0d748-75e2-11e3-9405-c21fceef8c63.png)

![skipped](https://f.cloud.github.com/assets/2125405/1846287/e6378b5a-75e2-11e3-8c13-71ccdc3627ee.png)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/angularjs-batarang/100)
<!-- Reviewable:end -->
