### PR TITLE
Prevent twice refresh

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -4,7 +4,7 @@ chrome.extension.onConnect.addListener(function(port) {
   port.onMessage.addListener(function (msg) {
     if (msg.action === 'register') {
       var respond = function (tabId, changeInfo, tab) {
-        if (tabId !== msg.inspectedTabId) {
+        if (tabId !== msg.inspectedTabId || changeInfo.status !== 'complete') {
           return;
         }
         port.postMessage('refresh');


### PR DESCRIPTION
The `chrome.tabs.onUpdated` fires twice for each page load: once with `changeInfo` status "loading" and once with status "complete". 
We are need to send `refresh` message only once, pehaps for 'complete' event.
