### PR TITLE
fix(dist/hint): don't throw in `getFunctionNames()` when `str` is not a string

### DIFF
--- a/dist/hint.js
+++ b/dist/hint.js
@@ -1993,6 +1993,7 @@ module.exports = function getEventDirectives() {
 'use strict';
 
 module.exports = function getFunctionNames(str) {
+  if (typeof str !== 'string') return [];
   var results = str.replace(/\s+/g, '').split(/[\+\-\/\|\<\>\^=&!%~]/g).map(function(x) {
     if(isNaN(+x)) {
       if(x.match(/\w+\(.*\)$/)){


### PR DESCRIPTION
Closes #166, Closes #172, Closes #174, Closes #177

<sub>(@btford: you'll have probably spotted that by now, but yeah...)</sub>
