### PR TITLE
fix(dist/hint): support object as 1st arg to `controller()`

### DIFF
--- a/dist/hint.js
+++ b/dist/hint.js
@@ -727,12 +727,22 @@ angular.module = function() {
       originalController = module.controller;
 
   module.controller = function(controllerName, controllerConstructor) {
-    nameToControllerMap[controllerName] = controllerConstructor;
-    sendMessageForControllerName(controllerName);
+    if ((controllerName !== null) && (typeof controllerName === 'object')) {
+      Object.keys(controllerName).forEach(function(key) {
+        processController(key, controllerName[key]);
+      });
+    } else {
+      processController(controllerName, controllerConstructor);
+    }
     return originalController.apply(this, arguments);
   };
   return module;
 };
+
+function processController(ctrlName, ctrlConstructor) {
+  nameToControllerMap[ctrlName] = ctrlConstructor;
+  sendMessageForControllerName(ctrlName);
+}
 
 },{"angular-hint-log":50}],5:[function(require,module,exports){
 'use strict';


### PR DESCRIPTION
Angular's `controller()` is overloaded: It either accepts a controller
name and a controller construction function or it accepts a map of
`key/value` pairs, `key` being a controller's name and `value` being its
contructor function.

Previously, 'dist/hint.js' was only able to handle the former case.

(Probably addresses a few problems reported in comments here and there.)

Closes #123
