### PR TITLE
fix(inspectedApp) support string ids

### DIFF
--- a/panel/components/inspected-app/inspected-app.js
+++ b/panel/components/inspected-app/inspected-app.js
@@ -48,7 +48,7 @@ function inspectedAppService($rootScope, $q) {
   };
 
   function invokeAngularHintMethod(method, scopeId, path, value) {
-    var args = [parseInt(scopeId, 10), path || ''].
+    var args = [scopeId, path || ''].
                   map(JSON.stringify).
                   concat(value ? [value] : []).
                   join(',');

--- a/panel/components/inspected-app/inspected-app.spec.js
+++ b/panel/components/inspected-app/inspected-app.spec.js
@@ -159,12 +159,16 @@ describe('inspectedApp', function() {
       expect(chrome.devtools.inspectedWindow.eval).toHaveBeenCalledWith('angular.hint.unwatch(1,"")');
     });
   });
-
-
+  
   describe('inspectScope', function () {
     it('should call chrome devtools APIs', function() {
       inspectedApp.inspectScope(2);
       expect(chrome.devtools.inspectedWindow.eval).toHaveBeenCalledWith('angular.hint.inspectScope(2,"")');
+    });
+
+    it('should handle angular 1.2 style string ids', function() {
+      inspectedApp.inspectScope('002');
+      expect(chrome.devtools.inspectedWindow.eval).toHaveBeenCalledWith('angular.hint.inspectScope("002","")');
     });
   });
 


### PR DESCRIPTION
The jsonTree was not displaying for angular 1.2 apps as inspectedApp was attempting to convert ids to integer form while angular 1.2 ids are strings. Removing conversion.

Fixes issue #231