### PR TITLE
fix(background.js) buffer de-serialized model info

### DIFF
--- a/panel/components/inspected-app/inspected-app.js
+++ b/panel/components/inspected-app/inspected-app.js
@@ -95,12 +95,11 @@ function inspectedAppService($rootScope, $q) {
             var parentScope = scopes[scope.parent];
             parentScope.children.splice(parentScope.children.indexOf(message.data.id), 1);
           }
-          for(var i = 0; i < message.data.subTree.length; i++){
+          for (var i = 0; i < message.data.subTree.length; i++){
             delete scopes[message.data.subTree[i]];
           }
         } else if (message.event === 'model:change') {
-          scope.models[message.data.path] = (typeof message.data.value === 'undefined') ?
-                                                undefined : JSON.parse(message.data.value);
+          scope.models[message.data.path] = message.data.value;
         } else if (message.event === 'scope:link') {
           scope.descriptor = message.data.descriptor;
         }

--- a/panel/components/inspected-app/inspected-app.spec.js
+++ b/panel/components/inspected-app/inspected-app.spec.js
@@ -108,11 +108,11 @@ describe('inspectedApp', function() {
         data: {
           id: id,
           path: '',
-          value: '"jsonHere"'
+          value: 'modelValue'
         }
       });
 
-      expect(inspectedApp.scopes[id].models['']).toEqual("jsonHere");
+      expect(inspectedApp.scopes[id].models['']).toEqual('modelValue');
     });
 
     it('should track model changes without throwing exception when values are missing', function () {


### PR DESCRIPTION
After devTools was closed and reopened the jsonTree showed raw json. This was because background.js was storing the model values as a json string. Since background.js and inspectedApp now both need the de-serialized representation of the model, moving the parsing code into background.js and replacing the string model with the de-serialized representation on the message itself, thus DRYing up the code.

Fixes issue #246

I'm not entirely sure why the model is passed around as json in the first place - hopefully me converting it back to an object within background.js isn't an issue.

I changed the name of the bufferOrForward function - it never is mutually exclusive so it should at least be called bufferAndSometimesForward :). What were doing though seems to be message brokering by the definition here https://en.wikipedia.org/wiki/Message_broker and using this name gives better context imho.