### PR TITLE
Background color needs to be specified

### DIFF
--- a/panel/app.css
+++ b/panel/app.css
@@ -1,3 +1,7 @@
+body {
+  background-color: rgb(255,255,255);
+}
+
 .col {
   float: left;
   width: 200px;


### PR DESCRIPTION
The background is transparent now. For some user who use chrome-dev-tool dark theme, text is hardly recognizable.

Looks terrible like following:
![screen shot 2015-09-02 at 10 50 34](https://cloud.githubusercontent.com/assets/6890034/9622050/e687aeea-5160-11e5-9e3c-6e3524cb70d2.png)

And there is my enhance by simply set `body {  background-color: rgb(255,255,255); }` in app.css
![screen shot 2015-09-02 at 10 58 08](https://cloud.githubusercontent.com/assets/6890034/9622123/a9a93d12-5161-11e5-8f89-85f4c5d2e1ab.png)

from #257 