### PR TITLE
fix(jsonTree) array expansion

### DIFF
--- a/panel/components/json-tree/json-tree.js
+++ b/panel/components/json-tree/json-tree.js
@@ -191,7 +191,7 @@ function byPathDepth(a, b) { // sort '' first
     return -1;
   } else if (b === '') {
     return 1;
-  } else { // sort by tree depth
-    return a.split('.').length - b.split('.').length;
+  } else { // sort by tree depth, and ensure array objects come before their members
+    return a.split(/[\.,\[]/).length - b.split(/[\.,\[]/).length;
   }
 }

--- a/panel/components/json-tree/json-tree.spec.js
+++ b/panel/components/json-tree/json-tree.spec.js
@@ -63,6 +63,89 @@ describe('batJsonTree', function () {
     });
   });
 
+  describe('processing of model data', function() {
+    it('should handle an element of an array being supplied before the array itself', function () {
+      $rootScope.data = {
+        '': {
+          arrayA: { '~array-length': 1 }
+        },
+        'arrayA[0]': { hello: 'world' },
+        'arrayA': [
+          { '~object': true }
+        ]
+      };
+      compileAndExpectOutputToEqual('arrayA: 0: hello: "world"');
+    });
+
+    it('should handle an element of an array being supplied after the array itself', function () {
+      $rootScope.data = {
+        '': {
+          arrayA: { '~array-length': 1 }
+        },
+        'arrayA': [
+          { '~object': true }
+        ],
+        'arrayA[0]': { hello: 'world' }
+      };
+      compileAndExpectOutputToEqual('arrayA: 0: hello: "world"');
+    });
+
+    it('should handle an object member being supplied after the object itself', function () {
+      $rootScope.data = {
+        '': {
+          objectA: { '~object': true }
+        },
+        objectA: {
+          objectB: { '~object': true }
+        },
+        'objectA.objectB': { hello: 'world' }
+      };
+      compileAndExpectOutputToEqual('objectA: objectB: hello: "world"');
+    });
+
+    it('should handle an object member being supplied before the object itself', function () {
+      $rootScope.data = {
+        '': {
+          objectA: { '~object': true }
+        },
+        'objectA.objectB': { hello: 'world' },
+        objectA: {
+          objectB: { '~object': true }
+        }
+      };
+      compileAndExpectOutputToEqual('objectA: objectB: hello: "world"');
+    });
+
+    it('should handle the root element being supplied first', function () {
+      $rootScope.data = {
+        '': {
+          objectA: { '~object': true }
+        },
+        objectA: {
+          hello: 'world'
+        }
+      };
+      compileAndExpectOutputToEqual('objectA: hello: "world"');
+    });
+
+    it('should handle the root element being supplied after another element', function () {
+      $rootScope.data = {
+        objectA: {
+          hello: 'world'
+        },
+        '': {
+          objectA: { '~object': true }
+        }
+      };
+      compileAndExpectOutputToEqual('objectA: hello: "world"');
+    });
+  });
+
+  function compileAndExpectOutputToEqual(expected) {
+    compileTree();
+    expect(element.text()).toEqual(expected);
+  }
+
   function compileTree() {
     element = compile('<bat-json-tree bat-model="data"></bat-json-tree>');
     $rootScope.$apply();


### PR DESCRIPTION
Intermittently arrays could not be expanded in the json tree. This occurred because the sort routine for model paths only accounted for parent child dependency between objects and their dot separated members and not between arrays and their elements. Updating the sort function to detect left bracket as path separator as well as dots.