### PR TITLE
For https://github.com/angular/batarang/issues/84

### DIFF
--- a/dist/hint.js
+++ b/dist/hint.js
@@ -2103,7 +2103,8 @@ var TYPES = [
   'ng-app',
   'ng-controller',
   'ng-repeat',
-  'ng-include'
+  'ng-include',
+  'ng-batarang'
 ];
 
 function scopeDescriptor (elt, scope) {
@@ -2120,7 +2121,11 @@ function scopeDescriptor (elt, scope) {
     }
   }
   if (theseTypes.length === 0) {
-    return 'scope.$id=' + scope.$id;
+    if (scope.$description === scope.$parent.$description){
+      // Don't use $description from $parent
+      return 'scope.$id=' + scope.$id;
+    }
+    return scope.$description || 'scope.$id=' + scope.$id;
   } else {
     return theseTypes.join(' ');
   }


### PR DESCRIPTION
There are two options for developers show their scope description in Batarang scope tree:

1. Using attribute. 
I propose to use 'ng-batarang' attribute. It works like the ng-app, ng-controller, etc currently supported in Batarang.
Please note that there is NO additional directive required for ng-batarang. The ng-batarang attribute is just be there for Batarang to look up the scope description.
2. Setting scope description by code. 
And I propose to use $description property.