### PR TITLE
Performance watchers right

### DIFF
--- a/panel/app.css
+++ b/panel/app.css
@@ -355,6 +355,10 @@ li .status:empty {
   font-size: 1.2em;
 }
 
+.perf .watcher-table .watcher-text {
+  text-align: right;
+}
+
 /* for the canvas */
 .graph {
   background: black;

--- a/panel/perf/perf.html
+++ b/panel/perf/perf.html
@@ -24,7 +24,7 @@
   <table class="watcher-table">
     <thead>
       <tr>
-        <td>Watcher text</td>
+        <td class="watcher-text">Watcher text</td>
         <td>Watcher total time</td>
         <td>Number of Watchers</td>
         <td>Average watcher time</td>
@@ -32,7 +32,7 @@
     </thead>
     <tbody>
       <tr ng-repeat="watcher in watchTimings">
-        <td><pre>{{ watcher.text }}</pre></td>
+        <td class="watcher-text"><pre>{{ watcher.text }}</pre></td>
         <td><pre>{{ watcher.time | number }} ms</pre></td>
         <td><pre>{{ watcher.count }}</pre></td>
         <td><pre>{{ watcher.time / watcher.count | number }} ms</pre></td>


### PR DESCRIPTION
It is difficult to read the watcher-text with watchers stats (total time...) when there is very long watcher texts (for example, a function body in a single line).

Here the proposal is to align right the watcher text to make easy to read all toghether.

An alternative, _not implemented here_, is to change order of columns and reorder stats to be on the left, and align watcher text to left.