### PR TITLE
Allow to inspect Angular2+ component inspection

### DIFF
--- a/devtoolsBackground.js
+++ b/devtoolsBackground.js
@@ -14,21 +14,37 @@ if (elementsPanel) {
 
 // The function below is executed in the context of the inspected page.
 function getPanelContents() {
+  var ng = window.ng;
   var angular = window.angular;
   var panelContents = {};
 
-  if (angular && $0) {
-    var scope = getScope($0);
+  if ($0) {
+    if (ng) {
+      var probe = ng.probe($0);
 
-    // Export $scope to the console
-    window.$scope = scope;
+      if (probe) {
+        // Export componentInstance to the console as an AngularJS scope
+        window.$scope = probe.componentInstance;
 
-    // Get sidebar contents
-    panelContents.__private__ = {};
-    Object.keys(scope).forEach(function (prop) {
-      var dest = (prop.substr(0, 2) === '$$') ? panelContents.__private__ : panelContents;
-      dest[prop] = scope[prop];
-    });
+        // Get sidebar contents
+        panelContents.__private__ = probe;
+        Object.keys(probe.componentInstance).forEach(function (prop) {
+          panelContents[prop] = probe.componentInstance[prop];
+        });
+      }
+    } else if (angular) {
+      var scope = getScope($0);
+
+      // Export $scope to the console
+      window.$scope = scope;
+
+      // Get sidebar contents
+      panelContents.__private__ = {};
+      Object.keys(scope).forEach(function (prop) {
+        var dest = (prop.substr(0, 2) === '$$') ? panelContents.__private__ : panelContents;
+        dest[prop] = scope[prop];
+      });
+    }
   }
 
   return panelContents;


### PR DESCRIPTION
The goal of this feature is to provide a very simple way to inspect an Angular component instance. It should be as easy as inspecting an AngularJS scope with Batarang.
I think it will help users used to AngularJS and Batarang to start development and debug on Angular2+.

**Example of Angular2 debugging with Batarang**
![2017-06-15_22-24-44](https://user-images.githubusercontent.com/1006426/27200461-08ab3ba2-521a-11e7-8936-286853b62c52.gif)

Related to https://github.com/angular/batarang/issues/235